### PR TITLE
3/25 작업 내용

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="dataSourceStorageLocal" created-in="IU-243.26053.27">
-    <data-source name="@localhost" uuid="f536ff39-5811-497a-b3bd-891db9fb37a5">
+    <data-source name="Delivery" uuid="1b23eeb3-8c5b-41db-a4b7-070e9dc26e04">
       <database-info product="MySQL" version="8.0.36" jdbc-version="4.2" driver-name="MySQL Connector/J" driver-version="mysql-connector-j-8.2.0 (Revision: 06a1f724497fd81c6a659131fda822c9e5085b6c)" dbms="MYSQL" exact-version="8.0.36" exact-driver-version="8.2">
         <extra-name-characters>#@</extra-name-characters>
         <identifier-quote-string>`</identifier-quote-string>
+        <jdbc-catalog-is-schema>true</jdbc-catalog-is-schema>
       </database-info>
       <case-sensitivity plain-identifiers="lower" quoted-identifiers="lower" />
       <secret-storage>master_key</secret-storage>
@@ -15,19 +16,6 @@
             <name qname="@" />
             <name qname="delivery" />
           </node>
-        </introspection-scope>
-      </schema-mapping>
-    </data-source>
-    <data-source name="delivery@localhost" uuid="111ed019-2fa1-4c6a-b214-8031500e63fe">
-      <database-info product="MySQL" version="8.0.36" jdbc-version="4.2" driver-name="MySQL Connector/J" driver-version="mysql-connector-j-8.2.0 (Revision: 06a1f724497fd81c6a659131fda822c9e5085b6c)" dbms="MYSQL" exact-version="8.0.36" exact-driver-version="8.2">
-        <extra-name-characters>#@</extra-name-characters>
-        <identifier-quote-string>`</identifier-quote-string>
-      </database-info>
-      <case-sensitivity plain-identifiers="lower" quoted-identifiers="lower" />
-      <user-name>root</user-name>
-      <schema-mapping>
-        <introspection-scope>
-          <node kind="schema" qname="@" />
         </introspection-scope>
       </schema-mapping>
     </data-source>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="@localhost" uuid="f536ff39-5811-497a-b3bd-891db9fb37a5">
+    <data-source source="LOCAL" name="Delivery" uuid="1b23eeb3-8c5b-41db-a4b7-070e9dc26e04">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
@@ -9,20 +9,7 @@
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
-        <property name="com.intellij.clouds.kubernetes.db.container.port" />
-      </jdbc-additional-properties>
-      <working-dir>$ProjectFileDir$</working-dir>
-    </data-source>
-    <data-source source="LOCAL" name="delivery@localhost" uuid="111ed019-2fa1-4c6a-b214-8031500e63fe">
-      <driver-ref>mysql.8</driver-ref>
-      <synchronize>true</synchronize>
-      <imported>true</imported>
-      <remarks>$PROJECT_DIR$/BE/src/main/resources/application.properties</remarks>
-      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://localhost:3306/delivery?useSSL=false&amp;serverTimezone=UTC</jdbc-url>
-      <jdbc-additional-properties>
-        <property name="com.intellij.clouds.kubernetes.db.host.port" />
-        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
         <property name="com.intellij.clouds.kubernetes.db.container.port" />
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>

--- a/.idea/dataSources/f536ff39-5811-497a-b3bd-891db9fb37a5.xml
+++ b/.idea/dataSources/f536ff39-5811-497a-b3bd-891db9fb37a5.xml
@@ -1068,7 +1068,7 @@ sys|schema||mysql.sys|localhost|TRIGGER|G</Grants>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
     <schema id="290" parent="1" name="delivery">
-      <LastIntrospectionLocalTimestamp>2025-03-22.11:11:41</LastIntrospectionLocalTimestamp>
+      <LastIntrospectionLocalTimestamp>2025-03-25.09:58:10</LastIntrospectionLocalTimestamp>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
     <schema id="291" parent="1" name="information_schema">
@@ -1321,7 +1321,7 @@ sys|schema||mysql.sys|localhost|TRIGGER|G</Grants>
       <Predicate>`price` &gt;= 0</Predicate>
     </check>
     <column id="349" parent="306" name="id">
-      <AutoIncrement>2</AutoIncrement>
+      <AutoIncrement>8</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>
@@ -1672,7 +1672,7 @@ category_id</ColNames>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
     <column id="418" parent="313" name="id">
-      <AutoIncrement>4</AutoIncrement>
+      <AutoIncrement>6</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,28 +4,38 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="dfb28497-9435-4471-b7e4-b25c23754bea" name="변경" comment="3/22 작업 내용&#10;Store - 가게 조회 (카테고리 기준) 기능 구현&#10;&#10;StoreCategory - 가게와 카테고리를 잇는 중간 테이블 구현&#10;&#10;Menu - 카테고리 추가시 이미 값이 있는지 검사 -&gt; 값이 없다면 추가 + 메뉴와 연결된 가게에도 같이 카테고리 추가&#10;&#10;복합키 - MenuCategory와 StoreCategory에 복합키 구성">
-      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/UpdateMenuDTO.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/UpdateOptionDTO.java" afterDir="false" />
+    <list default="true" id="dfb28497-9435-4471-b7e4-b25c23754bea" name="변경" comment="3/24 작업 내용&#10;Menu - 메뉴 수정 및 삭제 기능 구현&#10;&#10;OptionGroup - 옵션 그룹 수정 및 삭제 기능 구현&#10;&#10;Option - 옵션 수정 및 삭제 기능 구현&#10;&#10;Spring Security - 권한 설정 가독성 있게 변경&#10;&#10;기타 - 불필요한 import 및 DTO 필드 제거">
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/CartController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/CartItemController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/CreateCartItemDTO.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/CreateCartItemOptionDTO.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/ResponseCartDTO.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemDTO.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemOptionDTO.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Cart.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/CartItem.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/CartItemOption.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/CartItemOptionRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/CartItemRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/CartRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/CartItemOptionService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/CartItemService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/CartService.java" afterDir="false" />
       <change afterPath="$PROJECT_DIR$/BE/src/main/resources/application.properties" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/dataSources.local.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources.local.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/dataSources.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/dataSources/f536ff39-5811-497a-b3bd-891db9fb37a5.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources/f536ff39-5811-497a-b3bd-891db9fb37a5.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Config/SecurityConfig.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/CategoryController.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/CategoryController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/MenuController.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/MenuController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/OptionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/OptionController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/OptionGroupController.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Controller/OptionGroupController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/CreateMenuDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/CreateMenuDTO.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/ResponseStoreDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/ResponseStoreDTO.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/UpdateStoreDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/DTO/UpdateStoreDTO.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Category.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Category.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Member.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Menu.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Menu.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/AddressRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/AddressRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/MenuCategoryRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/MenuCategoryRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/StoreRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/StoreRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/MenuService.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/MenuService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/OptionGroupService.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/OptionGroupService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/OptionService.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/OptionService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/StoreService.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/StoreService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/OptionGroup.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/OptionGroup.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Store.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Domain/Store.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/OptionGroupRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Repository/OptionGroupRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/RegisterService.java" beforeDir="false" afterPath="$PROJECT_DIR$/BE/src/main/java/Delivery/BE/Service/RegisterService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -188,7 +198,8 @@
       <workItem from="1742360645532" duration="25463000" />
       <workItem from="1742635617313" duration="12499000" />
       <workItem from="1742786656330" duration="700000" />
-      <workItem from="1742788509733" duration="3783000" />
+      <workItem from="1742788509733" duration="4256000" />
+      <workItem from="1742897234957" duration="13576000" />
     </task>
     <task id="LOCAL-00001" summary="end">
       <option name="closed" value="true" />
@@ -310,7 +321,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742648646233</updated>
     </task>
-    <option name="localTasksCounter" value="16" />
+    <task id="LOCAL-00016" summary="3/24 작업 내용&#10;Menu - 메뉴 수정 및 삭제 기능 구현&#10;&#10;OptionGroup - 옵션 그룹 수정 및 삭제 기능 구현&#10;&#10;Option - 옵션 수정 및 삭제 기능 구현&#10;&#10;Spring Security - 권한 설정 가독성 있게 변경&#10;&#10;기타 - 불필요한 import 및 DTO 필드 제거">
+      <option name="closed" value="true" />
+      <created>1742810410112</created>
+      <option name="number" value="00016" />
+      <option name="presentableId" value="LOCAL-00016" />
+      <option name="project" value="LOCAL" />
+      <updated>1742810410112</updated>
+    </task>
+    <option name="localTasksCounter" value="17" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -331,7 +350,8 @@
     <MESSAGE value="3/18 작업 내용&#10;예외 처리 - UserNotFoundException.java와 AddressNotFoundException.java 삭제 후 NotFoundException으로 통일&#10;&#10;Store - 가게 수정 API 구현&#10;&#10;JWT - JWT인증 필터의 역할 변경 -&gt; 유효성 검증 실패 시 예외처리를 하던 것에서 검증 실패 시 SecurityContextHolder에 null 값을 넣는 것으로 대체 (Spring Security의 권한 설정이 가능하게 끔)" />
     <MESSAGE value="3/19 작업 내용&#10;Store - 가게 수정, 삭제 기능 구현&#10;&#10;Menu - 메뉴 생성 기능 구현&#10;&#10;Category - 미리 정해진 카테고리 DB에 저장&#10;&#10;MenuCategory - 메뉴에 카테고리 저장 하는 기능 구현&#10;&#10;Option/OptionGroup - 메뉴의 다양한 옵션들을 저장할 수 있는 기능 구현&#10;&#10;입력값 검증 - DTO에서 입력값 설정 후 컨트롤러에서 검증 하도록 변경&#10;&#10;Spring Security - 스프링 시큐리티의 권한을 가져오는 부분에 논리적 오류 수정 (Role_ 관련)&#10;&#10;기타 - 각 서비스에서 여러 레포지토리와 연결 되어 기능 사용하는 상황에서 -&gt; 각 서비스에서 다른 서비스의 기능을 사용하도록 변경 (비즈니스 로직의 분리, 재사용성 용이)" />
     <MESSAGE value="3/22 작업 내용&#10;Store - 가게 조회 (카테고리 기준) 기능 구현&#10;&#10;StoreCategory - 가게와 카테고리를 잇는 중간 테이블 구현&#10;&#10;Menu - 카테고리 추가시 이미 값이 있는지 검사 -&gt; 값이 없다면 추가 + 메뉴와 연결된 가게에도 같이 카테고리 추가&#10;&#10;복합키 - MenuCategory와 StoreCategory에 복합키 구성" />
-    <option name="LAST_COMMIT_MESSAGE" value="3/22 작업 내용&#10;Store - 가게 조회 (카테고리 기준) 기능 구현&#10;&#10;StoreCategory - 가게와 카테고리를 잇는 중간 테이블 구현&#10;&#10;Menu - 카테고리 추가시 이미 값이 있는지 검사 -&gt; 값이 없다면 추가 + 메뉴와 연결된 가게에도 같이 카테고리 추가&#10;&#10;복합키 - MenuCategory와 StoreCategory에 복합키 구성" />
+    <MESSAGE value="3/24 작업 내용&#10;Menu - 메뉴 수정 및 삭제 기능 구현&#10;&#10;OptionGroup - 옵션 그룹 수정 및 삭제 기능 구현&#10;&#10;Option - 옵션 수정 및 삭제 기능 구현&#10;&#10;Spring Security - 권한 설정 가독성 있게 변경&#10;&#10;기타 - 불필요한 import 및 DTO 필드 제거" />
+    <option name="LAST_COMMIT_MESSAGE" value="3/24 작업 내용&#10;Menu - 메뉴 수정 및 삭제 기능 구현&#10;&#10;OptionGroup - 옵션 그룹 수정 및 삭제 기능 구현&#10;&#10;Option - 옵션 수정 및 삭제 기능 구현&#10;&#10;Spring Security - 권한 설정 가독성 있게 변경&#10;&#10;기타 - 불필요한 import 및 DTO 필드 제거" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/BE/src/main/java/Delivery/BE/Config/SecurityConfig.java
+++ b/BE/src/main/java/Delivery/BE/Config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                                 , "/auth/**")
                         .permitAll()
 
-                        .requestMatchers("/role/**", "/address/**")
+                        .requestMatchers("/role/**", "/address/**", "/cart/**", "/cart-item/**")
                         .hasAnyRole("CUSTOMER", "OWNER", "ADMIN")
 
                         .requestMatchers("/store/**", "/menu/**", "/option-group/**", "/option/**")

--- a/BE/src/main/java/Delivery/BE/Controller/CartController.java
+++ b/BE/src/main/java/Delivery/BE/Controller/CartController.java
@@ -1,0 +1,25 @@
+package Delivery.BE.Controller;
+
+import Delivery.BE.DTO.ResponseCartDTO;
+import Delivery.BE.Domain.CartItem;
+import Delivery.BE.Service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+
+    @GetMapping("")
+    public ResponseEntity<?> getCartItemsList() { // 사용자의 장바구니에 저장된 데이터 조회
+        ResponseCartDTO responseCartDTO = cartService.getCartItems();
+        return ResponseEntity.ok(responseCartDTO);
+    }
+}

--- a/BE/src/main/java/Delivery/BE/Controller/CartItemController.java
+++ b/BE/src/main/java/Delivery/BE/Controller/CartItemController.java
@@ -1,0 +1,24 @@
+package Delivery.BE.Controller;
+
+import Delivery.BE.DTO.CreateCartItemDTO;
+import Delivery.BE.Service.CartItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cart-item")
+@RequiredArgsConstructor
+public class CartItemController {
+    private final CartItemService cartItemService;
+
+    @PostMapping("")
+    public ResponseEntity<?> addCartItem(@Valid @RequestBody CreateCartItemDTO createCartItemDTO) {
+        cartItemService.addCartItem(createCartItemDTO);
+        return ResponseEntity.ok("장바구니에 메뉴 추가 완료"); // 메뉴의 옵션까지 포함해서 저장
+    }
+}

--- a/BE/src/main/java/Delivery/BE/Controller/OptionGroupController.java
+++ b/BE/src/main/java/Delivery/BE/Controller/OptionGroupController.java
@@ -23,7 +23,7 @@ public class OptionGroupController {
     @PatchMapping("/{id}")
     public ResponseEntity<?> updateOptionGroup(@PathVariable Long id, @RequestBody UpdateOptionGroupDTO updateOptionGroupDTO) {
         optionGroupService.updateOptionGroup(id, updateOptionGroupDTO);
-        return ResponseEntity.ok("옵션 수정 완료");
+        return ResponseEntity.ok("옵션 그룹 수정 완료");
     }
 
     @DeleteMapping("/{id}")

--- a/BE/src/main/java/Delivery/BE/DTO/CreateCartItemDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/CreateCartItemDTO.java
@@ -1,0 +1,19 @@
+package Delivery.BE.DTO;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreateCartItemDTO {
+    @NotNull(message = "menuId는 빈칸일 수 없습니다.")
+    private Long menuId;
+
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    private int quantity;
+
+    @NotNull(message = "추가 할 옵션이 없다면 빈 리스트를 보내주세요.")
+    private List<Long> optionIds;
+}

--- a/BE/src/main/java/Delivery/BE/DTO/CreateCartItemOptionDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/CreateCartItemOptionDTO.java
@@ -1,0 +1,17 @@
+package Delivery.BE.DTO;
+
+import Delivery.BE.Domain.CartItem;
+import Delivery.BE.Domain.Option;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateCartItemOptionDTO {
+    @NotNull(message = "option은 빈칸일 수 없습니다.")
+    private final Option option;
+
+    @NotNull(message = "cartItem은 빈칸일 수 없습니다.")
+    private final CartItem cartItem;
+}

--- a/BE/src/main/java/Delivery/BE/DTO/CreateMenuDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/CreateMenuDTO.java
@@ -15,7 +15,7 @@ public class CreateMenuDTO {
 
     private String description;         // 메뉴 설명
 
-    @Min(value = 0, message = "가격은 0원 이상이여야 합니다.")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
     private int price;               // 메뉴 가격
 
     private String imageUrl;            // 메뉴 이미지 경로

--- a/BE/src/main/java/Delivery/BE/DTO/ResponseCartDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/ResponseCartDTO.java
@@ -1,0 +1,20 @@
+package Delivery.BE.DTO;
+
+import Delivery.BE.Domain.CartItem;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class ResponseCartDTO {
+    private List<ResponseCartItemDTO> cartItems;
+
+    public ResponseCartDTO(List<CartItem> cartItems) {
+        this.cartItems = cartItems.stream().map(cartItem -> new ResponseCartItemDTO(
+                cartItem.getQuantity(),
+                cartItem.getMenu(),
+                cartItem.getCartItemOptions()
+        )).collect(Collectors.toList());
+    }
+}

--- a/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemDTO.java
@@ -1,0 +1,29 @@
+package Delivery.BE.DTO;
+
+import Delivery.BE.Domain.CartItemOption;
+import Delivery.BE.Domain.Menu;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class ResponseCartItemDTO {
+    private int quantity;
+    private String name;
+    private String description;
+    private int price;
+    private String imageUrl;
+    private List<ResponseCartItemOptionDTO> cartItemOptions;
+
+    public ResponseCartItemDTO(int quantity, Menu menu, List<CartItemOption> cartItemOptionList) {
+        this.quantity = quantity;
+        this.name = menu.getName();
+        this.description = menu.getDescription();
+        this.price = menu.getPrice();
+        this.imageUrl = menu.getImageUrl();
+        this.cartItemOptions = cartItemOptionList.stream().map(cartItemOption -> new ResponseCartItemOptionDTO(
+                cartItemOption.getOption()
+        )).collect(Collectors.toList());
+    }
+}

--- a/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemOptionDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/ResponseCartItemOptionDTO.java
@@ -1,0 +1,17 @@
+package Delivery.BE.DTO;
+
+import Delivery.BE.Domain.Option;
+import lombok.Data;
+
+@Data
+public class ResponseCartItemOptionDTO {
+    private String optionGroupName; // 옵션 그룹 이름
+    private String optionName; // 옵션 이름
+    private int price; // 옵션 가격
+
+    public ResponseCartItemOptionDTO(Option option) {
+        this.optionName = option.getName();
+        this.optionGroupName = option.getOptionGroup().getName();
+        this.price = option.getPrice();
+    }
+}

--- a/BE/src/main/java/Delivery/BE/DTO/ResponseStoreDTO.java
+++ b/BE/src/main/java/Delivery/BE/DTO/ResponseStoreDTO.java
@@ -38,8 +38,8 @@ public class ResponseStoreDTO {
     private Timestamp updatedAt;
 
     public ResponseStoreDTO(Long id, String name, Member member, String description, String phone, String address
-    , Store.Status status, String openingHours, String logoUrl, Double rating, Set<Category> categories
-    , Timestamp createdAt, Timestamp updatedAt) {
+            , Store.Status status, String openingHours, String logoUrl, Double rating, Set<Category> categories
+            , Timestamp createdAt, Timestamp updatedAt) {
         this.id = id;
         this.name = name;
         this.memberId = member.getId();

--- a/BE/src/main/java/Delivery/BE/Domain/Cart.java
+++ b/BE/src/main/java/Delivery/BE/Domain/Cart.java
@@ -1,0 +1,27 @@
+package Delivery.BE.Domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "cart")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Cart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false) // Member 와 연결
+    private Member member;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems = new ArrayList<>();
+}

--- a/BE/src/main/java/Delivery/BE/Domain/CartItem.java
+++ b/BE/src/main/java/Delivery/BE/Domain/CartItem.java
@@ -1,0 +1,34 @@
+package Delivery.BE.Domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "cart_item")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id", nullable = false) // Member 와 연결
+    private Cart cart;
+
+    @ManyToOne
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @OneToMany(mappedBy = "cartItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItemOption> cartItemOptions = new ArrayList<>();
+}

--- a/BE/src/main/java/Delivery/BE/Domain/CartItemOption.java
+++ b/BE/src/main/java/Delivery/BE/Domain/CartItemOption.java
@@ -1,0 +1,25 @@
+package Delivery.BE.Domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "cart_item_option")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_item_id", nullable = false) // CartItem 와 연결
+    private CartItem cartItem;
+
+    @ManyToOne
+    @JoinColumn(name = "option_id", nullable = false) // Option 과 연결
+    private Option option;
+}

--- a/BE/src/main/java/Delivery/BE/Domain/Member.java
+++ b/BE/src/main/java/Delivery/BE/Domain/Member.java
@@ -43,8 +43,8 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Store> stores = new ArrayList<>();
 
-    @Column(name = "main_address")
-    private Long mainAddress;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Cart cart;
 
     public enum Role {
         CUSTOMER,   // 손님

--- a/BE/src/main/java/Delivery/BE/Domain/Menu.java
+++ b/BE/src/main/java/Delivery/BE/Domain/Menu.java
@@ -3,6 +3,8 @@ package Delivery.BE.Domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 
@@ -36,6 +38,9 @@ public class Menu {
 
     @Column(name = "is_available", nullable = false)
     private boolean isAvailable;        // 메뉴 이용 가능 여부
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OptionGroup> optionGroups = new ArrayList<>();
 
     @ManyToMany
     @JoinTable(

--- a/BE/src/main/java/Delivery/BE/Domain/OptionGroup.java
+++ b/BE/src/main/java/Delivery/BE/Domain/OptionGroup.java
@@ -3,6 +3,9 @@ package Delivery.BE.Domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -21,4 +24,7 @@ public class OptionGroup {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @OneToMany(mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Option> options = new ArrayList<>();
 }

--- a/BE/src/main/java/Delivery/BE/Domain/Store.java
+++ b/BE/src/main/java/Delivery/BE/Domain/Store.java
@@ -6,6 +6,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -48,6 +50,9 @@ public class Store {
 
     @Column(name = "rating") // 가게 평점
     private Double rating;
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Menu> menus = new ArrayList<>();
 
     @ManyToMany
     @JoinTable(

--- a/BE/src/main/java/Delivery/BE/Repository/CartItemOptionRepository.java
+++ b/BE/src/main/java/Delivery/BE/Repository/CartItemOptionRepository.java
@@ -1,12 +1,9 @@
 package Delivery.BE.Repository;
 
-import Delivery.BE.Domain.OptionGroup;
+import Delivery.BE.Domain.CartItemOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
-
+public interface CartItemOptionRepository extends JpaRepository<CartItemOption, Long> {
 }

--- a/BE/src/main/java/Delivery/BE/Repository/CartItemRepository.java
+++ b/BE/src/main/java/Delivery/BE/Repository/CartItemRepository.java
@@ -1,12 +1,9 @@
 package Delivery.BE.Repository;
 
-import Delivery.BE.Domain.OptionGroup;
+import Delivery.BE.Domain.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
-
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 }

--- a/BE/src/main/java/Delivery/BE/Repository/CartRepository.java
+++ b/BE/src/main/java/Delivery/BE/Repository/CartRepository.java
@@ -1,12 +1,9 @@
 package Delivery.BE.Repository;
 
-import Delivery.BE.Domain.OptionGroup;
+import Delivery.BE.Domain.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
-
+public interface CartRepository extends JpaRepository<Cart, Long> {
 }

--- a/BE/src/main/java/Delivery/BE/Service/CartItemOptionService.java
+++ b/BE/src/main/java/Delivery/BE/Service/CartItemOptionService.java
@@ -1,0 +1,31 @@
+package Delivery.BE.Service;
+
+import Delivery.BE.DTO.CreateCartItemOptionDTO;
+import Delivery.BE.Domain.CartItem;
+import Delivery.BE.Domain.CartItemOption;
+import Delivery.BE.Domain.Option;
+import Delivery.BE.Repository.CartItemOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartItemOptionService {
+    private final CartItemOptionRepository cartItemOptionRepository;
+
+    @Transactional
+    public void addCartItemOption(CreateCartItemOptionDTO createCartItemOptionDTO) {
+        // ID 로 각각의 객체를 받아서
+        CartItem cartItem = createCartItemOptionDTO.getCartItem();
+        Option option = createCartItemOptionDTO.getOption();
+
+        // 장바구니 메뉴의 옵션으로 추가
+        CartItemOption cartItemOption = CartItemOption.builder()
+                .cartItem(cartItem)
+                .option(option)
+                .build();
+
+        cartItemOptionRepository.save(cartItemOption);
+    }
+}

--- a/BE/src/main/java/Delivery/BE/Service/CartItemService.java
+++ b/BE/src/main/java/Delivery/BE/Service/CartItemService.java
@@ -1,0 +1,60 @@
+package Delivery.BE.Service;
+
+import Delivery.BE.DTO.CreateCartItemDTO;
+import Delivery.BE.DTO.CreateCartItemOptionDTO;
+import Delivery.BE.Domain.Cart;
+import Delivery.BE.Domain.CartItem;
+import Delivery.BE.Domain.Member;
+import Delivery.BE.Domain.Menu;
+import Delivery.BE.Exception.NotFoundException;
+import Delivery.BE.Repository.CartItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CartItemService {
+    private final CartItemRepository cartItemRepository;
+    private final CartService cartService;
+    private final MenuService menuService;
+    private final MemberService memberService;
+    private final CartItemOptionService cartItemOptionService;
+    private final OptionService optionService;
+
+    @Transactional
+    public void addCartItem(CreateCartItemDTO createCartItemDTO) {
+        Member member = memberService.getMemberInfo();
+        Cart cart = cartService.findCartById(member.getCart().getId());
+
+        Menu menu = menuService.findMenuById(createCartItemDTO.getMenuId());
+
+        CartItem cartItem = CartItem.builder()
+                .cart(cart)
+                .menu(menu)
+                .quantity(createCartItemDTO.getQuantity())
+                .build();
+
+        cartItemRepository.save(cartItem);
+
+        List<Long> list = createCartItemDTO.getOptionIds();
+
+        if(list != null && !list.isEmpty()) { // 옵션 ID가 저장된 리스트가 1개 이상의 데이터를 가지고 있다면
+            for(Long optionId : list) {
+                CreateCartItemOptionDTO createCartItemOptionDTO = CreateCartItemOptionDTO.builder()
+                        .cartItem(findCartItemById(cartItem.getId()))
+                        .option(optionService.findOptionById(optionId))
+                        .build(); // 장바구니 메뉴 ID 와 옵션 ID 를 DTO 로 만들어서
+
+                cartItemOptionService.addCartItemOption(createCartItemOptionDTO); // 장바구니 메뉴의 옵션을 추가
+            }
+        }
+    }
+
+    public CartItem findCartItemById(Long id) {
+        return cartItemRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("장바구니 메뉴를 찾을 수 없습니다. ID: " + id));
+    }
+}

--- a/BE/src/main/java/Delivery/BE/Service/CartService.java
+++ b/BE/src/main/java/Delivery/BE/Service/CartService.java
@@ -1,0 +1,45 @@
+package Delivery.BE.Service;
+
+import Delivery.BE.DTO.ResponseCartDTO;
+import Delivery.BE.Domain.Cart;
+import Delivery.BE.Domain.CartItem;
+import Delivery.BE.Domain.Member;
+import Delivery.BE.Exception.NotFoundException;
+import Delivery.BE.Repository.CartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+    private final MemberService memberService;
+    private final CartRepository cartRepository;
+
+    @Transactional
+    public void saveCart(Member member) {
+        Cart cart = Cart.builder()
+                .member(member)
+                .build();
+
+        cartRepository.save(cart);
+    }
+
+    public ResponseCartDTO getCartItems() {
+        Member member = memberService.getMemberInfo(); // 사용자 정보를 가져와서
+        Long id = member.getCart().getId(); // 사용자의 장바구니 id 가져오기
+
+        Cart cart = findCartById(id);
+        List<CartItem> cartItems = cart.getCartItems();
+
+        return new ResponseCartDTO(cartItems);
+    }
+
+    public Cart findCartById(Long id) {
+        return cartRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("장바구니를 찾을 수 없습니다. ID: " + id));
+    }
+}

--- a/BE/src/main/java/Delivery/BE/Service/RegisterService.java
+++ b/BE/src/main/java/Delivery/BE/Service/RegisterService.java
@@ -1,6 +1,7 @@
 package Delivery.BE.Service;
 
 import Delivery.BE.DTO.RegisterDTO;
+import Delivery.BE.Domain.Cart;
 import Delivery.BE.Domain.Member;
 import Delivery.BE.Exception.AlreadyRegisteredException;
 import Delivery.BE.Exception.InformationNotMatchException;
@@ -17,6 +18,7 @@ import java.util.Objects;
 @Transactional // update중 오류가 나면 자동 롤백
 public class RegisterService {
     private final MemberRepository memberRepository;
+    private final CartService cartService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public void register(RegisterDTO registerDTO) {
@@ -36,6 +38,8 @@ public class RegisterService {
                 .build();
 
         memberRepository.save(member);
+
+        cartService.saveCart(member);
     }
 
     private void validateUserId(RegisterDTO registerDTO) {


### PR DESCRIPTION
DB - 장바구니 관련 테이블 추가 (Cart, CartItem, CartItemOption), Order랑 OderItem은 임시 제거 (추후 기능 구현시 다시 짤 생각)

Cart - 장바구니 조회 기능 구현 (DTO를 통해 필요한 데이터만 형식에 맞춰 반환)

CartItem - 장바구니에 메뉴 추가 기능 구현 (메뉴 추가시 각 메뉴에 따른 옵션도 같이 추가)

기타 - 장바구니는 회원가입시 1:1의 관계(Member - Cart)로 생성하기 위해 RegisterService 수정

다음에 해야할 것 (까먹을까봐 여기도 적는다) - 장바구니에 비우기, 장바구니 메뉴, 옵션 수정 및 삭제, 가게에서 옵션 생성시 중복 가능 여부 (ex 마라탕의 토핑은 중복 가능, 햄버거의 세트 유무는 중복 불가), 그에 따른 예외처리